### PR TITLE
Add support for unofficial opening hours

### DIFF
--- a/internal/api/openinghoursapi/get_opening_hours.go
+++ b/internal/api/openinghoursapi/get_opening_hours.go
@@ -17,9 +17,14 @@ type GetOpeningHoursRangeResponse struct {
 	Dates map[string] /*2006-01-02*/ GetOpeningHoursResponse `json:"dates"`
 }
 
+type TimeRange struct {
+	daytime.TimeRange
+	Unofficial bool `json:"unofficial"`
+}
+
 type GetOpeningHoursResponse struct {
-	Frames    []daytime.TimeRange `json:"openingHours"`
-	IsHoliday bool                `json:"holiday"`
+	Frames    []TimeRange `json:"openingHours"`
+	IsHoliday bool        `json:"holiday"`
 }
 
 func GetOpeningHoursEndpoint(router *app.Router) {
@@ -70,9 +75,12 @@ func getSingleDayOpeningHours(ctx context.Context, app *app.App, at string, d ti
 		return nil, err
 	}
 
-	timeRanges := make([]daytime.TimeRange, len(frames))
+	timeRanges := make([]TimeRange, len(frames))
 	for idx, frame := range frames {
-		timeRanges[idx] = *frame.At(d, app.Location())
+		timeRanges[idx] = TimeRange{
+			TimeRange:  *frame.At(d, app.Location()),
+			Unofficial: frame.Unofficial,
+		}
 	}
 
 	return &GetOpeningHoursResponse{

--- a/internal/cfgspec/opening_hours.go
+++ b/internal/cfgspec/opening_hours.go
@@ -43,6 +43,12 @@ type OpeningHours struct {
 
 	// Holiday controls whether this setting is in effect on holidays.
 	Holiday string
+
+	// Unofficial can be set to true if the opening hour is unofficial. That is,
+	// the entry door will be opened but no "work shift" is assigned for that specific
+	// time frame and the doctor-on-duty is responsible instead.
+	// TODO(ppacher): rework/rethink this together with tkd/cis#2.
+	Unofficial bool
 }
 
 // OpeningHoursSpec describes the different configuratoin stanzas for the OpeningHours struct.
@@ -86,6 +92,12 @@ var OpeningHoursSpec = conf.SectionSpec{
 		Name:        "OnCallNightStart",
 		Type:        conf.StringType,
 		Description: "Defines the time the night-shift for the on-call doctor starts. This also denotes the end of the prvious day shift. Format is HH:MM in the configured timezone.",
+	},
+	{
+		Name:        "Unofficial",
+		Type:        conf.BoolType,
+		Description: "can be set to true if the opening hour is unofficial. That is, the entry door will be opened but no 'work shift' is assigned for that specific time frame and the doctor-on-duty is responsible instead.",
+		Default:     "no",
 	},
 }
 

--- a/internal/openinghours/door.go
+++ b/internal/openinghours/door.go
@@ -223,6 +223,7 @@ func NewDoorController(cfg cfgspec.Config, timeRanges []cfgspec.OpeningHours, ho
 				DayTimeRange: tr,
 				CloseAfter:   closeAfter,
 				OpenBefore:   openBefore,
+				Unofficial:   c.Unofficial,
 			})
 		}
 

--- a/internal/openinghours/opening_hour.go
+++ b/internal/openinghours/opening_hour.go
@@ -13,6 +13,7 @@ import (
 type OpeningHour struct {
 	daytime.DayTimeRange
 
+	Unofficial bool          `json:"unofficial"`
 	Holiday    bool          `json:"holiday"`
 	OpenBefore time.Duration `json:"closeBefore"`
 	CloseAfter time.Duration `json:"closeAfter"`

--- a/spec/tests/opening-hours.spec.ts
+++ b/spec/tests/opening-hours.spec.ts
@@ -1,0 +1,80 @@
+import { Alice } from '../utils';
+
+describe("OpeningHours", () => {
+    describe("retrieving opening hours", () => {
+        it("should work for a specific date", async () => {
+            const response = await Alice.get("http://localhost:3000/api/openinghours/v1/opening-hours?at=2021-10-23")
+            expect(response.data).toEqual({
+                openingHours: [
+                    {
+                        from: "2021-10-23T09:00:00+02:00",
+                        to: "2021-10-23T12:00:00+02:00",
+                        unofficial: false
+                    }
+                ],
+                holiday: false
+            })
+        })
+
+        it("should work for a holiday date", async () => {
+            const response = await Alice.get("http://localhost:3000/api/openinghours/v1/opening-hours?at=2021-10-26")
+            expect(response.data).toEqual({
+                openingHours: [
+                    {
+                        from: "2021-10-26T09:00:00+02:00",
+                        to: "2021-10-26T12:00:00+02:00",
+                        unofficial: true
+                    }
+                ],
+                holiday: true
+            })
+        })
+
+        it("should support retrieving ranges", async () => {
+            const response = await Alice.get("http://localhost:3000/api/openinghours/v1/opening-hours?from=2021-10-23&to=2021-10-27")
+            expect(response.data).toEqual({
+                "dates": {
+                    "2021-10-23T00:00:00+02:00": {
+                        "openingHours": [
+                            {
+                                "from": "2021-10-23T09:00:00+02:00",
+                                "to": "2021-10-23T12:00:00+02:00",
+                                "unofficial": false
+                            }
+                        ],
+                        "holiday": false
+                    },
+                    "2021-10-24T00:00:00+02:00": {
+                        "openingHours": [],
+                        "holiday": false
+                    },
+                    "2021-10-25T00:00:00+02:00": {
+                        "openingHours": [
+                            {
+                                "from": "2021-10-25T08:00:00+02:00",
+                                "to": "2021-10-25T12:00:00+02:00",
+                                "unofficial": false
+                            },
+                            {
+                                "from": "2021-10-25T14:00:00+02:00",
+                                "to": "2021-10-25T17:00:00+02:00",
+                                "unofficial": false
+                            }
+                        ],
+                        "holiday": false
+                    },
+                    "2021-10-26T00:00:00+02:00": {
+                        "openingHours": [
+                            {
+                                "from": "2021-10-26T09:00:00+02:00",
+                                "to": "2021-10-26T12:00:00+02:00",
+                                "unofficial": false
+                            }
+                        ],
+                        "holiday": true
+                    }
+                }
+            })
+        })
+    })
+})

--- a/testdata/config/conf.d/opening-hours.conf
+++ b/testdata/config/conf.d/opening-hours.conf
@@ -32,7 +32,12 @@ CloseAfter=0m
 # This setting only applies to holidays in addition to the specifc
 # date set above.
 Holiday=only
+Unofficial=yes
 
 [OpeningHour]
 OnWeekday=Sun
 OnCallDayStart=08:30
+# this opening hour is unoffical so the door should
+# open but there should not be any "roster work shift"
+# for it.
+Unofficial=yes

--- a/ui/src/app/api/openinghours.api.ts
+++ b/ui/src/app/api/openinghours.api.ts
@@ -19,6 +19,7 @@ export type DayTime = [number, number];
 export interface OpeningHour<T = Date> {
     from: T;
     to: T;
+    unofficial: boolean;
 }
 
 @Injectable({
@@ -43,6 +44,7 @@ export class OpeningHoursAPI {
                         openingHours: res.dates[key].openingHours.map(frame => ({
                             from: new Date(frame.from),
                             to: new Date(frame.to),
+                            unofficial: frame.unofficial,
                         }))
                     }
                 })
@@ -74,6 +76,7 @@ export class OpeningHoursAPI {
                 openingHours: res.openingHours.map(frame => ({
                     from: new Date(frame.from),
                     to: new Date(frame.to),
+                    unofficial: frame.unofficial,
                 }))
             }))
         );

--- a/ui/src/app/pages/roster/roster.ts
+++ b/ui/src/app/pages/roster/roster.ts
@@ -457,8 +457,8 @@ export class RosterComponent extends CdkScrollable implements OnInit, OnDestroy 
       Object.keys(range.dates).forEach(key => {
         const date = new Date(key);
         const lunch = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0).getTime();
-        const hasForenoon = range.dates[key].openingHours.some(frame => frame.to.getTime() <= lunch);
-        const hasAfternoon = range.dates[key].openingHours.some(frame => frame.to.getTime() > lunch);
+        const hasForenoon = range.dates[key].openingHours.some(frame => frame.to.getTime() <= lunch && !frame.unofficial);
+        const hasAfternoon = range.dates[key].openingHours.some(frame => frame.to.getTime() > lunch && !frame.unofficial);
         this.openingHours[key] = {
           frames: range.dates[key].openingHours,
           hasAfternoon: hasAfternoon,


### PR DESCRIPTION
This PR adds support for unofficial opening hours. An opening hour time frame can now be marked as "unofficial" which causes the entry door to be unlocked as usual but also instructs the duty roster UI to **not** show a work shift.
Instead, the doctor-on-duty will be responsible.

This is related to #5 and will get obsolete when it is merged. Though, this PR provides a "quick fix" so the roster does not allow shift configuration for work-days where the doctor-on-duty should be responsible. 